### PR TITLE
chore: pin Trivy image to a fixed version and digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ NC := \033[0m # No Color
 COMPOSE_FILE := docker-compose.yml
 COMPOSE_OVERRIDE := docker-compose.override.yml
 
+# Pinned tools (tag for readability, digest for immutability/reproducibility)
+TRIVY_IMAGE := aquasec/trivy:0.71.2@sha256:f5d0e600ecda7449e2a9b272805aef698631d3bb3f3a739a750de2c6819acdc9
+
 ## Environment Management
 up: ## Start the complete testing environment
 	@echo "$(BLUE)🐳 Starting Symfony OpenTelemetry Bundle Test Environment$(NC)"
@@ -388,7 +391,7 @@ lint-yaml: ## Lint YAML files
 
 security-scan: ## Run local security scanning
 	@echo "$(BLUE)🔒 Running local security scan...$(NC)"
-	@docker run --rm -v $(PWD):/workspace aquasec/trivy fs --security-checks vuln /workspace
+	@docker run --rm -v $(PWD):/workspace $(TRIVY_IMAGE) fs --scanners vuln /workspace
 	@echo "$(GREEN)✅ Security scan completed$(NC)"
 
 fix-whitespace: ## Fix trailing whitespace in all files


### PR DESCRIPTION
## Summary

The `security-scan` Makefile target ran `aquasec/trivy` with **no tag**, so it resolved to `:latest` on every invocation — a floating, non-reproducible scanner whose behavior can change (or break) silently between runs.

This change:

- **Pins the scanner** to `aquasec/trivy:0.71.2` by both tag (readability) and digest (immutability), via a new `TRIVY_IMAGE` variable that follows the file's existing `:=` convention.
- **Replaces the deprecated `--security-checks` flag with `--scanners`.** The old flag was renamed in Trivy v0.37.0 and later removed; modern releases (including the pinned 0.71.2) reject it. This edit is required for the pinned version to run at all.

```diff
-	@docker run --rm -v $(PWD):/workspace aquasec/trivy fs --security-checks vuln /workspace
+	@docker run --rm -v $(PWD):/workspace $(TRIVY_IMAGE) fs --scanners vuln /workspace
```

## Why it matters

`:latest` is a supply-chain and reproducibility risk for a security tool — the binary that produces your vulnerability results should be a known, immutable artifact. The pinned digest (`sha256:f5d0e60…`) is the multi-arch image index, so it works on both amd64 and arm64 runners.

## Validation

- `make -n security-scan` expands cleanly to the pinned image + `--scanners` flag.
- Digest resolved directly from the Docker Hub registry API for tag `0.71.2`.

## Follow-up suggestion

Add a Renovate/Dependabot rule to keep `TRIVY_IMAGE` current so the pin doesn't go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)